### PR TITLE
Patch for US and Asia regions short names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Unreleased
 
-Fixed:
+Fixed
   * [GITHUB-7](https://github.com/claranet/terraform-azurerm-regions/issues/7): Fix US and Asia regions short names
 
 # v6.1.0 - 2022-11-02
 
-Added:
+Added
   * [GITHUB-6](https://github.com/claranet/terraform-azurerm-regions/pull/6): Add West US 3 region
 
 # v6.0.0 - 2022-07-08
@@ -52,46 +52,46 @@ Added:
 
 # v3.0.1/v4.0.0 - 2020-10-20
 
-Changed:
+Changed
   * AZ-273: Update README and CI, module compatible Terraform 0.13+ (now requires Terraform 0.12.26 minimum version)
 
 # v2.0.2/v3.0.0 - 2020-04-02
 
-Changed:
+Changed
   * AZ-206: Update README, module compatible both AzureRM provider < 2.0 and >= 2.0
 
 # v2.0.1 - 2019-09-27
 
-Changed:
+Changed
   * AZ-119: Revamp README and publish this module to Terraform registry
 
-Added:
+Added
   * AZ-119: Add CONTRIBUTING.md doc and `terraform-wrapper` usage with the module
 
 # v2.0.0 - 2019-09-06
 
-Breaking:
+Breaking
   * AZ-94: Terraform 0.12 / HCL2 format
 
-Added:
+Added
   * AZ-118: Add LICENSE, NOTICE & Github badges
 
 # v1.1.0 - 2019-05-06
 
-Changed:
+Changed
   * AZ-88: Normalize `location_short` variable
 
 # v1.0.1 - 2019-01-14
 
-Added:
+Added
   * AZ-3: Continuous integration & migration on GitLab CI
 
 # v1.0.0 - 2018-07-09
 
-Changed:
+Changed
   * TER-295: Update Azure Regions and add short format.
 
 # v0.0.1 - 2018-03-12
 
-Added:
+Added
   * First Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+# Unreleased
+
+Fixed:
+  * [GITHUB-7](https://github.com/claranet/terraform-azurerm-regions/issues/7): Fix US and Asia regions short names
+
 # v6.1.0 - 2022-11-02
 
-Added
+Added:
   * [GITHUB-6](https://github.com/claranet/terraform-azurerm-regions/pull/6): Add West US 3 region
 
 # v6.0.0 - 2022-07-08
@@ -47,46 +52,46 @@ Added:
 
 # v3.0.1/v4.0.0 - 2020-10-20
 
-Changed
+Changed:
   * AZ-273: Update README and CI, module compatible Terraform 0.13+ (now requires Terraform 0.12.26 minimum version)
 
 # v2.0.2/v3.0.0 - 2020-04-02
 
-Changed
+Changed:
   * AZ-206: Update README, module compatible both AzureRM provider < 2.0 and >= 2.0
 
 # v2.0.1 - 2019-09-27
 
-Changed
+Changed:
   * AZ-119: Revamp README and publish this module to Terraform registry
 
-Added
+Added:
   * AZ-119: Add CONTRIBUTING.md doc and `terraform-wrapper` usage with the module
 
 # v2.0.0 - 2019-09-06
 
-Breaking
+Breaking:
   * AZ-94: Terraform 0.12 / HCL2 format
 
-Added
+Added:
   * AZ-118: Add LICENSE, NOTICE & Github badges
 
 # v1.1.0 - 2019-05-06
 
-Changed
+Changed:
   * AZ-88: Normalize `location_short` variable
 
 # v1.0.1 - 2019-01-14
 
-Added
+Added:
   * AZ-3: Continuous integration & migration on GitLab CI
 
 # v1.0.0 - 2018-07-09
 
-Changed
+Changed:
   * TER-295: Update Azure Regions and add short format.
 
 # v0.0.1 - 2018-03-12
 
-Added
+Added:
   * First Release

--- a/REGIONS.md
+++ b/REGIONS.md
@@ -2,15 +2,15 @@
 
 | Region name          | Short notation | Internal terraform notation |
 | -------------------- | -------------- | --------------------------- |
-| East US              | ue             | us-east                     |
-| East US 2            | ue2            | us-east-2                   |
-| Central US           | uc             | us-central                  |
-| North Central US     | unc            | us-north-central            |
-| South Central US     | usc            | us-south-central            |
-| West Central US      | uwc            | us-west-central             |
-| West US              | uw             | us-west                     |
-| West US 2            | uw2            | us-west-2                   |
-| West US 3            | uw3            | us-west-3                   |
+| East US              | use            | us-east                     |
+| East US 2            | use2           | us-east-2                   |
+| Central US           | usc            | us-central                  |
+| North Central US     | usnc           | us-north-central            |
+| South Central US     | ussc           | us-south-central            |
+| West Central US      | uswc           | us-west-central             |
+| West US              | usw            | us-west                     |
+| West US 3            | usw3           | us-west-3                   |
+| West US 2            | usw2           | us-west-2                   |
 | Canada East          | cae            | can-east                    |
 | Canada Central       | cac            | can-central                 |
 | Brazil South         | brs            | bra-south                   |
@@ -28,8 +28,9 @@
 | Switzerland West     | sww            | swz-west                    |
 | Norway East          | noe            | norw-east                   |
 | Norway West          | now            | norw-west                   |
-| Southeast Asia       | ase            | asia-south-east             |
-| East Asia            | ae             | asia-east                   |
+| Southeast Asia       | asse           | asia-south-east             |
+| East Asia            | asea           | asia-east                   |
+| Asia Pacific         | apac           | asia-pa                     |
 | Australia East       | aue            | aus-east                    |
 | Australia Southeast  | ause           | aus-south                   |
 | Australia Central    | auc            | aus-central                 |

--- a/regions.tf
+++ b/regions.tf
@@ -69,16 +69,20 @@ locals {
     "us"      = "United States"
   }
 
+  /* Short names based on the following rules (where possible) to have better clarity:
+    - contains at least 3 chars, where 2 chars represents global part (continent)
+    - use ISO 3166 code of country concatenation
+  */
   short_names = {
-    "us-east"          = "ue"
-    "us-east-2"        = "ue2"
-    "us-central"       = "uc"
-    "us-north-central" = "unc"
-    "us-south-central" = "usc"
-    "us-west-central"  = "uwc"
-    "us-west"          = "uw"
-    "us-west-2"        = "uw2"
-    "us-west-3"        = "uw3"
+    "us-east"          = "use"
+    "us-east-2"        = "use2"
+    "us-central"       = "usc"
+    "us-north-central" = "usnc"
+    "us-south-central" = "ussc"
+    "us-west-central"  = "uswc"
+    "us-west"          = "usw"
+    "us-west-2"        = "usw2"
+    "us-west-3"        = "usw3"
     "can-east"         = "cae"
     "can-central"      = "cac"
     "bra-south"        = "brs"
@@ -97,8 +101,8 @@ locals {
     "swz-west"         = "sww"
     "norw-east"        = "noe"
     "norw-west"        = "now"
-    "asia-south-east"  = "ase"
-    "asia-east"        = "ae"
+    "asia-south-east"  = "asse"
+    "asia-east"        = "asea"
     "aus-east"         = "aue"
     "aus-south-east"   = "ause"
     "aus-central"      = "auc"
@@ -122,17 +126,17 @@ locals {
     "uae-north"        = "uaen"
 
     # Global/continental zones
-    "asia"    = "asia"   # Asia
-    "asia-pa" = "asiapa" # Asia Pacific
-    "aus"     = "aus"    # Australia
-    "bra"     = "bra"    # Brazil
-    "can"     = "can"    # Canada
-    "eu"      = "eu"     # Europe
-    "global"  = "glob"   # Global
-    "ind"     = "ind"    # India
-    "jap"     = "jap"    # Japan
-    "uk"      = "uk"     # United Kingdom
-    "us"      = "us"     # United States
+    "asia"    = "asia" # Asia
+    "asia-pa" = "apac" # Asia Pacific
+    "aus"     = "aus"  # Australia
+    "bra"     = "bra"  # Brazil
+    "can"     = "can"  # Canada
+    "eu"      = "eu"   # Europe
+    "global"  = "glob" # Global
+    "ind"     = "ind"  # India
+    "jap"     = "jap"  # Japan
+    "uk"      = "uk"   # United Kingdom
+    "us"      = "us"   # United States
   }
 
   # Thoses region CLI name where partially generated via

--- a/regions.tf
+++ b/regions.tf
@@ -70,7 +70,7 @@ locals {
   }
 
   /* Short names based on the following rules (where possible) to have better clarity:
-    - contains at least 3 chars, where 2 chars represents global part (continent)
+    - contains at least 3 chars, where 2 chars represent global part (continent)
     - use ISO 3166 code of country concatenation
   */
   short_names = {


### PR DESCRIPTION
Fixes #7  .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- All US-based regions short names: contain `us` instead of `u` for region representation (except Gov-related);
- Asia regions short names: contain `as` instead of `a` for region representation (except APAC):
  - Southeast Asia moved from `ase` to `asse`
  - East Asia moved to `asea` to not have intersection and double-meaning with previous `ase` which was Southeast Asia
  - Asia Pacific renamed to `apac` to represent most common short name for this region

@claranet/fr-azure-reviewers
