### PR TITLE
Update regions.tf to fix data residency typo

### DIFF
--- a/regions.tf
+++ b/regions.tf
@@ -360,7 +360,7 @@ locals {
     "swz-west"         = "Switzerland"   # Switzerland West
     "uae-central"      = "UAE"           # UAE Central
     "uae-north"        = "UAE"           # UAE North
-    "uk-south"         = "UAE"           # UK South
+    "uk-south"         = "UK"            # UK South
     "uk"               = "UK"            # United Kingdom
     "uk-west"          = "UK"            # UK West
     "us-central"       = "United States" # Central US


### PR DESCRIPTION
Fixed typo in data_residency section, it implies data is stored in UAE when it is actually in the UK.

Fixes #14  .

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- Updates UK South data residency to show correct location (UK rather than UAE)

@claranet/fr-azure-reviewers
